### PR TITLE
Fix Google Sheets logging and sync question pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+/.claude
 
 # dependencies
 /node_modules
@@ -21,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+CLAUDE.md

--- a/src/App.js
+++ b/src/App.js
@@ -104,44 +104,63 @@ const App = () => {
     return selectedQuestions;
   };
 
-// Function to send data to Google Sheets
+// Append a failed/unsent result to localStorage so it's never lost.
+const queueResultLocally = (data) => {
+  if (!window.localStorage) return;
+  try {
+    const saved = JSON.parse(localStorage.getItem('triviaPSResults') || '[]');
+    saved.push(data);
+    localStorage.setItem('triviaPSResults', JSON.stringify(saved));
+    console.log('Saved result to localStorage as fallback');
+  } catch (e) {
+    console.error('Error saving to localStorage:', e);
+  }
+};
+
+// Function to send data to Google Sheets.
+// Never throws — returns { success } and falls back to localStorage on failure.
 const sendDataToGoogleSheets = async (data) => {
   // Use the URL from your deployment
   const webAppUrl = 'https://script.google.com/macros/s/AKfycbytfh6JZFtSU6vdaQQY8thzxWlZKWZ4jMeOKBbsvYkAtKBFWO8duHsnn_k5DBQtqfMG2g/exec';
-  
+
   try {
-    // Add no-cors mode for development
+    // Send as text/plain so the browser treats this as a "simple" CORS request: no
+    // preflight, and Apps Script returns the response with the CORS header we can read.
+    // (application/json would trigger a preflight OPTIONS that Apps Script can't answer.)
+    // Unlike the old no-cors mode, this lets us actually see whether the write succeeded.
     const response = await fetch(webAppUrl, {
       method: 'POST',
-      mode: 'no-cors', // This is important for cross-origin requests during development
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'text/plain;charset=utf-8',
       },
       body: JSON.stringify(data),
+      redirect: 'follow',
     });
 
-    // Since no-cors mode doesn't return readable response, handle it differently
-    console.log('Request sent to Google Sheets');
-    
-    // For no-cors mode, we can't access the response body
-    // Just return a success message
-    return { success: true, message: "Data likely sent successfully" };
-  } catch (error) {
-    console.error('Error sending data to Google Sheets:', error);
-    
-    // Implement a fallback - save to localStorage
-    if (window.localStorage) {
-      try {
-        const savedResults = JSON.parse(localStorage.getItem('triviaPSResults') || '[]');
-        savedResults.push(data);
-        localStorage.setItem('triviaPSResults', JSON.stringify(savedResults));
-        console.log('Saved results to localStorage as fallback');
-      } catch (e) {
-        console.error('Error saving to localStorage:', e);
-      }
+    // e.g. HTTP 403 when the deployment's access is restricted, or 5xx from the script.
+    if (!response.ok) {
+      throw new Error(`Google Sheets responded with HTTP ${response.status}`);
     }
-    
-    throw error;
+
+    // Apps Script returns JSON like { result: "success", data: "..." }.
+    // A non-JSON body still counts as delivered, since the HTTP status was OK.
+    let body = null;
+    try {
+      body = await response.json();
+    } catch (e) {
+      // ignore — treat as success based on HTTP status
+    }
+
+    if (body && body.result && body.result !== 'success') {
+      throw new Error(`Google Sheets reported: ${JSON.stringify(body)}`);
+    }
+
+    console.log('Result successfully recorded to Google Sheets');
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to send data to Google Sheets:', error);
+    queueResultLocally(data);
+    return { success: false, error: String(error) };
   }
 };
 

--- a/src/questions.js
+++ b/src/questions.js
@@ -85,14 +85,23 @@ export const questions = {
           { text: "Commerce and CompSci, Machine Learning and AI", isCorrect: false },
         ],
       },
-      
+
     ],
-    
-    
-    
-    
-    
+
+
+
+
+
     normal: [
+      {
+        text: "What's Pyae Sone's favorite album of 2026?",
+        answers: [
+          { text: "OCTANE by Don Toliver", isCorrect: true },
+          { text: "BULLY by Kanye West", isCorrect: false },
+          { text: "All three albums of Drake", isCorrect: false },
+          { text: "Deadbeat by Tame Impala", isCorrect: false },
+        ],
+      },
       {
         text: "What’s the name of the first album Pyae Sone ever obsessed over?",
         answers: [
@@ -100,6 +109,15 @@ export const questions = {
           { text: "Vultures by Kanye West", isCorrect: false },
           { text: "For all the dogs by Drake", isCorrect: false },
           { text: "After Hours by the Weekend", isCorrect: false },
+        ],
+      },
+      {
+        text: "What kind of football fan is Pyae Sone?",
+        answers: [
+          { text: "Plastic Fan", isCorrect: false },
+          { text: "Hardcore Man United Supporter", isCorrect: false },
+          { text: "Neutral, just a football admirer", isCorrect: true },
+          { text: "Performative, bro knows nothing about football", isCorrect: false },
         ],
       },
       {
@@ -154,6 +172,7 @@ export const questions = {
           { text: "Iced Latte with two sugar", isCorrect: false },
           { text: "Iced Long Black", isCorrect: false },
           { text: "Mocha with skim milk", isCorrect: false },
+          { text: "No, he perfomative and drink matcha latte", isCorrect: false },
         ],
       },
       {
@@ -182,15 +201,15 @@ export const questions = {
           { text: "The Big Bang Theory", isCorrect: false },
         ],
       }
-      
+
     ],
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
     hard: [
       {
         text: "How much is Pyae Sone's rating on Chess.com?",
@@ -230,15 +249,6 @@ export const questions = {
         ],
       },
       {
-        text: "What is Pyae Sone's favorite Pokémon?",
-        answers: [
-          { text: "Pikachu", isCorrect: false },
-          { text: "Charizard", isCorrect: false },
-          { text: "Mewtwo", isCorrect: false },
-          { text: "Gyrados", isCorrect: true },
-        ],
-      },
-      {
         text: "Which FIFA Pyae Sone has spent most time on?",
         answers: [
           { text: "FIFA 20", isCorrect: false },
@@ -268,10 +278,11 @@ export const questions = {
       {
         text: "What color switch of mechanical keypress is Pyae Sone's Favorite?",
         answers: [
-          { text: "Red", isCorrect: true },
+          { text: "Red", isCorrect: false },
           { text: "Blue", isCorrect: false },
           { text: "Brown", isCorrect: false },
           { text: "Trick question, he likes membrane keys", isCorrect: false },
+          { text: "Purple", isCorrect: true },
         ],
       },
       {
@@ -283,6 +294,15 @@ export const questions = {
           { text: "Chess.com", isCorrect: false },
         ],
       },
-      
+      {
+        text: "What is Pyae Sone's dream watch in 2026?",
+        answers: [
+          { text: "Rolex Submariner", isCorrect: false },
+          { text: "Audemars Piguet (AP) Royal Oak", isCorrect: false },
+          { text: "Tudor Black Bay 58", isCorrect: true },
+          { text: "Patek Phillipe Annual Calendar", isCorrect: false },
+        ],
+      },
+
     ],
   };


### PR DESCRIPTION
The quiz results stopped reaching the Google Sheet. Root cause is the Apps Script deployment now returning 403 (access restricted), but the client used mode: 'no-cors' and so could never see the failure -- it always logged success and never fell back.

- Rewrite sendDataToGoogleSheets to send a "simple" text/plain CORS request (no preflight, readable response), check response.ok and the script's result payload, and reliably queue to localStorage on any failure. Never throws.
- Sync questions.js with Questions.txt: add the 2026-album, football-fan, and dream-watch questions and a 5th coffee option; change mechanical switch answer Red -> Purple; drop the duplicated Pokemon question. Pools are now easy:10, normal:12, hard:10 (each with one correct answer).
- Ignore /.claude and CLAUDE.md.